### PR TITLE
Compiling Structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "ion"
 version = "0.1.0"
 authors = ["PhilippGackstatter <philipp.gackstatter@student.tuwien.ac.at>"]
 edition = "2018"
-path = "src/lib.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,44 @@ Since it is type checked at compile time, calling `fibonacci("100")` would error
               ^^^^^ Function parameters have incompatible type. Expected: i32, Supplied: str.
 ```
 
+Another Example with Structs.
+
+```
+struct Dog {
+    name: str,
+    age: i32,
+}
+
+struct Owner {
+    name: str,
+    dog: Dog,
+}
+
+fn execute() {
+    var owner = Owner {
+        name: "John",
+        dog: Dog {
+            name: "Nemo",
+            age: 2,
+        },
+    };
+
+    owner.name = "John, the dog owner";
+
+    print owner.name;
+    print owner.dog.name;
+}
+
+execute();
+```
+
+That would print
+
+```
+John, the dog owner
+Nemo
+```
+
 ## Run
 
 All you need is `cargo` & `rustc`. Written with `rustc 1.37.0`, but should work with much earlier versions as well.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ fn execute() {
         },
     };
 
-    owner.name = "John, the dog owner";
+    owner.dog.name = "Finding me, is finding ...";
 
     print owner.name;
     print owner.dog.name;
@@ -82,8 +82,8 @@ execute();
 That would print
 
 ```
-John, the dog owner
-Nemo
+John
+Finding me, is finding ...
 ```
 
 ## Run

--- a/examples/struct_nesting.io
+++ b/examples/struct_nesting.io
@@ -1,0 +1,30 @@
+struct Dog {
+    name: str,
+    age: i32,
+}
+
+struct Owner {
+    name: str,
+    dog: Dog,
+}
+
+fn create_owner(owner_name: str) -> Owner {
+    return Owner {
+        name: owner_name,
+        dog: Dog {
+            name: "Nemo",
+            age: 2,
+        },
+    };
+}
+
+fn execute() {
+    var owner = create_owner("John");
+
+    owner.name = "John Dog Owner";
+
+    print owner.name;
+    print owner.dog.name;
+}
+
+execute();

--- a/examples/struct_nesting.io
+++ b/examples/struct_nesting.io
@@ -21,7 +21,7 @@ fn create_owner(owner_name: str) -> Owner {
 fn execute() {
     var owner = create_owner("John");
 
-    owner.name = "John Dog Owner";
+    owner.dog.name = "Finding me, is finding ...";
 
     print owner.name;
     print owner.dog.name;

--- a/examples/struct_rectangle.io
+++ b/examples/struct_rectangle.io
@@ -1,0 +1,15 @@
+struct Rectangle {
+    width: i32,
+    height: i32,
+}
+
+fn area(rect: Rectangle) -> i32 {
+    return rect.width * rect.height;
+}
+
+var rect = Rectangle {
+    width: 4,
+    height: 3,
+};
+
+print area(rect);

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -236,6 +236,7 @@ impl Compiler {
                     self.emit_u16(index);
                 }
             }
+            StructInit { .. } => {}
         }
     }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -190,13 +190,14 @@ impl Compiler {
 
                 self.emit_op_byte(Bytecode::OpCall);
             }
-            Assign(id, expr) => {
-                self.compile_expr(expr);
-                if let Some(index) = self.find_local_variable(&id) {
+            Assign { target, value } => {
+                self.compile_expr(value);
+                if let Some(index) = self.find_local_variable(&target.get_id()) {
                     self.emit_op_byte(Bytecode::OpSetLocal);
                     self.emit_byte(index);
                 } else {
-                    let index = self.add_constant(Value::Obj(Object::StringObj(id.clone())));
+                    let index =
+                        self.add_constant(Value::Obj(Object::StringObj(target.get_id().clone())));
                     self.emit_op_byte(Bytecode::OpSetGlobal);
                     self.emit_u16(index);
                 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -111,7 +111,7 @@ impl Compiler {
                 self.emit_op_byte(Bytecode::OpDefineGlobal);
                 self.emit_u16(index_name);
             }
-            StructDecl(_, _) => unimplemented!(),
+            StructDecl(_, _) => (),
         }
     }
 
@@ -237,7 +237,18 @@ impl Compiler {
                     self.emit_u16(index);
                 }
             }
-            StructInit { .. } => {}
+            StructInit { values, .. } => {
+                for (field_name, field_value) in values.iter() {
+                    self.compile_expr(field_value);
+                    let index =
+                        self.add_constant(Value::Obj(Object::StringObj(field_name.get_id())));
+                    self.emit_op_byte(Bytecode::OpConstant);
+                    self.emit_u16(index);
+                }
+
+                self.emit_op_byte(Bytecode::OpStructInit);
+                self.emit_byte(values.len().try_into().unwrap());
+            }
             Access { .. } => (),
         }
     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -237,6 +237,7 @@ impl Compiler {
                 }
             }
             StructInit { .. } => {}
+            Access { .. } => (),
         }
     }
 

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -249,7 +249,15 @@ impl Compiler {
                 self.emit_op_byte(Bytecode::OpStructInit);
                 self.emit_byte(values.len().try_into().unwrap());
             }
-            Access { .. } => (),
+            Access { expr, name } => {
+                self.compile_expr(expr);
+
+                let index = self.add_constant(Value::Obj(Object::StringObj(name.get_id())));
+                self.emit_op_byte(Bytecode::OpConstant);
+                self.emit_u16(index);
+
+                self.emit_op_byte(Bytecode::OpStructAccess);
+            }
         }
     }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -330,5 +330,4 @@ mod tests {
             expected
         );
     }
-
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -897,5 +897,4 @@ mod tests {
 
         assert_eq!(*parse_result.first().unwrap(), expected)
     }
-
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -405,6 +405,26 @@ impl<'a> Parser<'a> {
         ))
     }
 
+    fn struct_instantiation(&mut self) -> ExpressionResult {
+        let mut expr = self.primary()?;
+
+        if self.match_(LeftBrace) {
+            let mut fields = Vec::new();
+            while !self.match_(RightBrace) {
+                let field_name = self.primary()?;
+                if let Identifier(field) = &field_name {} else {
+                    Err(self.error(field_name.tokens, "Expected identifier as field name"));
+                }
+                self.consume(Colon, "Expected ':' in field initializer.")?;
+                let field_value = self.primary()?;
+                self.consume(Comma, "Expected ',' after field initializer.")?;
+                fields.push((field_name))
+            }
+        }
+
+        Ok(expr)
+    }
+
     fn primary(&mut self) -> ExpressionResult {
         // primary → NUMBER | STRING | "false" | "true" | "nil"
         //           | "(" expression ")" ;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -283,12 +283,16 @@ impl<'a> Parser<'a> {
         let left_hand = self.equality();
 
         if self.match_(Equal) {
+            let left_hand = left_hand?;
             let equals = self.previous().clone();
-            if let Identifier(id) = &left_hand?.kind {
-                let value = self.assignment()?;
+            let value = self.assignment()?;
+            if let Identifier(_) | Access { .. } = &left_hand.kind {
                 return Ok(Expression::new(
                     equals.into(),
-                    Assign(id.clone(), Box::new(value)),
+                    Assign {
+                        target: Box::new(left_hand),
+                        value: Box::new(value),
+                    },
                 ));
             } else {
                 return Err(self.error(equals.into(), "Invalid assignment target."));
@@ -728,14 +732,14 @@ mod tests {
                 token!(Less),
                 expr!(Integer { int: 3 }),
             )),
-            Box::new(ExpressionStmt(Expression::new_debug(Assign(
-                "i".into(),
-                expr!(Binary(
+            Box::new(ExpressionStmt(Expression::new_debug(Assign {
+                target: expr!(Identifier("i".into())),
+                value: expr!(Binary(
                     expr!(Identifier("i".into())),
                     token!(Plus),
                     expr!(Integer { int: 1 }),
                 )),
-            )))),
+            }))),
         ));
 
         assert_eq!(*parse_result.first().unwrap(), expected)
@@ -752,14 +756,14 @@ mod tests {
                 token!(BangEqual),
                 expr!(Integer { int: 3 }),
             )),
-            Box::new(ExpressionStmt(Expression::new_debug(Assign(
-                "x".into(),
-                expr!(Binary(
+            Box::new(ExpressionStmt(Expression::new_debug(Assign {
+                target: expr!(Identifier("x".into())),
+                value: expr!(Binary(
                     expr!(Integer { int: 10 }),
                     token!(Slash),
                     expr!(Integer { int: 2 }),
                 )),
-            )))),
+            }))),
             None,
         ));
 
@@ -777,22 +781,22 @@ mod tests {
                 token!(BangEqual),
                 expr!(Integer { int: 3 }),
             )),
-            Box::new(ExpressionStmt(Expression::new_debug(Assign(
-                "x".into(),
-                expr!(Binary(
+            Box::new(ExpressionStmt(Expression::new_debug(Assign {
+                target: expr!(Identifier("x".into())),
+                value: expr!(Binary(
                     expr!(Integer { int: 10 }),
                     token!(Slash),
                     expr!(Integer { int: 2 }),
                 )),
-            )))),
-            Some(Box::new(ExpressionStmt(Expression::new_debug(Assign(
-                "x".into(),
-                expr!(Binary(
+            }))),
+            Some(Box::new(ExpressionStmt(Expression::new_debug(Assign {
+                target: expr!(Identifier("x".into())),
+                value: expr!(Binary(
                     expr!(Integer { int: 15 }),
                     token!(Star),
                     expr!(Integer { int: 3 }),
                 )),
-            ))))),
+            })))),
         ));
 
         assert_eq!(*parse_result.first().unwrap(), expected)

--- a/src/test_input/type_checker/struct_access_assign.io
+++ b/src/test_input/type_checker/struct_access_assign.io
@@ -1,0 +1,8 @@
+struct NumWrap {
+    integer: i32,
+}
+
+{
+    var wrapper = NumWrap { integer: 234, };
+    wrapper.integer = "asdf";
+}

--- a/src/test_input/type_checker/struct_access_use.io
+++ b/src/test_input/type_checker/struct_access_use.io
@@ -1,0 +1,8 @@
+struct NumWrap {
+    integer: i32,
+}
+
+{
+    var wrapper = NumWrap { integer: 234, };
+    var y = !wrapper.integer;
+}

--- a/src/test_input/type_checker/struct_init_too_many.io
+++ b/src/test_input/type_checker/struct_init_too_many.io
@@ -1,0 +1,12 @@
+struct HTTPStatus {
+    code: i32,
+    msg: str,
+}
+
+{
+    var x = HTTPStatus {
+        code: 404,
+        msg: "NotFound",
+        another_field: "too many",
+    };
+}

--- a/src/test_input/type_checker/struct_init_wrong_field_name.io
+++ b/src/test_input/type_checker/struct_init_wrong_field_name.io
@@ -1,0 +1,11 @@
+struct HTTPStatus {
+    code: i32,
+    msg: str,
+}
+
+{
+    var x = HTTPStatus {
+        code: 404,
+        message: "NotFound",
+    };
+}

--- a/src/test_input/type_checker/struct_init_wrong_type.io
+++ b/src/test_input/type_checker/struct_init_wrong_type.io
@@ -1,0 +1,12 @@
+// Should fail since HTTPStatus' msg field has type str
+struct HTTPStatus {
+    code: i32,
+    msg: str,
+}
+
+{
+    var x = HTTPStatus {
+        code: 404,
+        msg: 404,
+    };
+}

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -756,4 +756,14 @@ mod tests {
         assert!(res.unwrap_err().message.contains("but type i32 was found"));
     }
 
+    #[test]
+    fn test_struct_access_use() {
+        let res = lex_parse_check("struct_access_use.io");
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .message
+            .contains("Type i32 can not be used with a ! operator"));
+    }
+
 }

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -404,43 +404,17 @@ impl TypeChecker {
             ExpressionKind::False { .. } => Ok(Type::new(expr.tokens.clone(), TypeKind::Bool)),
             ExpressionKind::Assign { target, value } => {
                 let value_type = self.check_expr(&value)?;
-                match &target.kind {
-                    ExpressionKind::Identifier(id) => {
-                        if let Some(index) = self.find_local_variable(&id) {
-                            // Assignment to local var
-                            if self.locals[index as usize].dtype != value_type {
-                                Err(CompileError {
-                                    token_range: value_type.token_range.clone(),
-                                    message: format!(
-                                        "Expression of type {} can not be assigned to variable with type {}",
-                                        value_type, self.locals[index as usize].dtype
-                                    ),
-                                })
-                            } else {
-                                Ok(value_type)
-                            }
-                        } else {
-                            // TODO: Assignment to global var
-                            Ok(value_type)
-                        }
-                    }
-                    ExpressionKind::Access { .. } => {
-                        let target_type = self.check_expr(target)?;
-                        if target_type != value_type {
-                            Err(CompileError {
-                                token_range: value_type.token_range.clone(),
-                                message: format!(
-                                    "Expression of type {} can not be assigned to variable of type {}",
-                                    value_type, target_type
-                                ),
-                            })
-                        } else {
-                            Ok(target_type)
-                        }
-                    }
-                    _ => {
-                        unreachable!();
-                    }
+                let target_type = self.check_expr(target)?;
+                if target_type != value_type {
+                    Err(CompileError {
+                        token_range: value_type.token_range.clone(),
+                        message: format!(
+                            "Expression of type {} can not be assigned to variable of type {}",
+                            value_type, target_type
+                        ),
+                    })
+                } else {
+                    Ok(target_type)
                 }
             }
             ExpressionKind::Identifier(id) => {

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -1,4 +1,6 @@
-use crate::types::{Declaration, Expression, ExpressionKind, Program, Statement, Token, TokenKind, CompileError};
+use crate::types::{
+    CompileError, Declaration, Expression, ExpressionKind, Program, Statement, Token, TokenKind,
+};
 use std::collections::{hash_map::Entry, HashMap};
 use std::convert::TryInto;
 use std::ops::Range;

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -402,25 +402,45 @@ impl TypeChecker {
             ExpressionKind::Str { .. } => Ok(Type::new(expr.tokens.clone(), TypeKind::Str)),
             ExpressionKind::True { .. } => Ok(Type::new(expr.tokens.clone(), TypeKind::Bool)),
             ExpressionKind::False { .. } => Ok(Type::new(expr.tokens.clone(), TypeKind::Bool)),
-            ExpressionKind::Assign(id, expr) => {
-                let expr_type = self.check_expr(&expr)?;
-
-                if let Some(index) = self.find_local_variable(&id) {
-                    // Assignment to local var
-                    if self.locals[index as usize].dtype != expr_type {
-                        Err(CompileError {
-                            token_range: expr_type.token_range.clone(),
-                            message: format!(
-                                "Expression of type {} can not be assigned to variable with type {}",
-                                expr_type, self.locals[index as usize].dtype
-                            ),
-                        })
-                    } else {
-                        Ok(expr_type)
+            ExpressionKind::Assign { target, value } => {
+                let value_type = self.check_expr(&value)?;
+                match &target.kind {
+                    ExpressionKind::Identifier(id) => {
+                        if let Some(index) = self.find_local_variable(&id) {
+                            // Assignment to local var
+                            if self.locals[index as usize].dtype != value_type {
+                                Err(CompileError {
+                                    token_range: value_type.token_range.clone(),
+                                    message: format!(
+                                        "Expression of type {} can not be assigned to variable with type {}",
+                                        value_type, self.locals[index as usize].dtype
+                                    ),
+                                })
+                            } else {
+                                Ok(value_type)
+                            }
+                        } else {
+                            // TODO: Assignment to global var
+                            Ok(value_type)
+                        }
                     }
-                } else {
-                    // TODO: Assignment to global var
-                    Ok(expr_type)
+                    ExpressionKind::Access { .. } => {
+                        let target_type = self.check_expr(target)?;
+                        if target_type != value_type {
+                            Err(CompileError {
+                                token_range: value_type.token_range.clone(),
+                                message: format!(
+                                    "Expression of type {} can not be assigned to variable of type {}",
+                                    value_type, target_type
+                                ),
+                            })
+                        } else {
+                            Ok(target_type)
+                        }
+                    }
+                    _ => {
+                        unreachable!();
+                    }
                 }
             }
             ExpressionKind::Identifier(id) => {
@@ -552,7 +572,7 @@ impl TypeChecker {
                 } else {
                     Err(CompileError {
                         token_range: expr.tokens.clone(),
-                        message: "Cannot instantiate anything other than a struct".to_owned(),
+                        message: "Cannot access anything other than a struct".to_owned(),
                     })
                 }
             }
@@ -764,6 +784,16 @@ mod tests {
             .unwrap_err()
             .message
             .contains("Type i32 can not be used with a ! operator"));
+    }
+
+    #[test]
+    fn test_struct_access_assign() {
+        let res = lex_parse_check("struct_access_assign.io");
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .message
+            .contains("Expression of type str can not be assigned to variable of type i32"));
     }
 
 }

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -709,4 +709,29 @@ mod tests {
             .message
             .contains("already declared in this scope"));
     }
+
+    #[test]
+    fn test_struct_init_too_many_fields() {
+        let res = lex_parse_check("struct_init_too_many.io");
+        assert!(res.is_err());
+        assert!(res
+            .unwrap_err()
+            .message
+            .contains("Expected 2 fields, but 3 were given"));
+    }
+
+    #[test]
+    fn test_struct_init_wrong_field_name() {
+        let res = lex_parse_check("struct_init_wrong_field_name.io");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().message.contains("has no field with name"));
+    }
+
+    #[test]
+    fn test_struct_init_wrong_type() {
+        let res = lex_parse_check("struct_init_wrong_type.io");
+        assert!(res.is_err());
+        assert!(res.unwrap_err().message.contains("but type i32 was found"));
+    }
+
 }

--- a/src/type_checker.rs
+++ b/src/type_checker.rs
@@ -769,5 +769,4 @@ mod tests {
             .message
             .contains("Expression of type str can not be assigned to variable of type i32"));
     }
-
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,6 +218,10 @@ pub enum ExpressionKind {
     Assign(String, Box<Expression>),
     Unary(Token, Box<Expression>),
     Call(Box<Expression>, Vec<Expression>),
+    Access {
+        expr: Box<Expression>,
+        name: Box<Expression>,
+    },
     StructInit {
         name: Box<Expression>,
         values: Vec<(Expression, Expression)>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::ops::Range;
+use std::collections::HashMap;
 
 pub type Program = Vec<Declaration>;
 
@@ -25,6 +26,7 @@ impl Value {
 pub enum Object {
     StringObj(String),
     FnObj(String, Chunk, u8),
+    StructObj { name: String, fields: HashMap<String, Value> },
 }
 
 #[derive(Debug)]
@@ -205,6 +207,7 @@ pub enum ExpressionKind {
     Assign(String, Box<Expression>),
     Unary(Token, Box<Expression>),
     Call(Box<Expression>, Vec<Expression>),
+    StructInit { name: Token, values: Vec<(Expression, Expression)> },
     Integer { int: i32 },
     Double { float: f32 },
     Str { string: String },
@@ -250,6 +253,7 @@ impl fmt::Display for Object {
         match self {
             Object::StringObj(str_) => write!(f, "{}", str_),
             Object::FnObj(name, _chunk, arity) => write!(f, "{} (args: {})", name, arity),
+            Object::StructObj { name, fields } => write!(f, "struct {}", name),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -221,7 +221,10 @@ pub enum Statement {
 #[derive(PartialEq)]
 pub enum ExpressionKind {
     Binary(Box<Expression>, Token, Box<Expression>),
-    Assign(String, Box<Expression>),
+    Assign {
+        target: Box<Expression>,
+        value: Box<Expression>,
+    },
     Unary(Token, Box<Expression>),
     Call(Box<Expression>, Vec<Expression>),
     Access {

--- a/src/types.rs
+++ b/src/types.rs
@@ -320,69 +320,60 @@ fn byte_to_opcode(
     bytes: &mut std::iter::Enumerate<std::slice::Iter<u8>>,
     constants: &[Value],
 ) -> Option<(usize, String)> {
+    use Bytecode::*;
+
     if let Some((index, byte_)) = bytes.next() {
         let byte = unsafe { std::mem::transmute::<u8, Bytecode>(*byte_) };
         let res = match byte {
-            Bytecode::OpPop => format!("{:?}", byte),
-            Bytecode::OpMul => format!("{:?}", byte),
-            Bytecode::OpAdd => format!("{:?}", byte),
-            Bytecode::OpDiv => format!("{:?}", byte),
-            Bytecode::OpSub => format!("{:?}", byte),
-            Bytecode::OpNot => format!("{:?}", byte),
-            Bytecode::OpEqual => format!("{:?}", byte),
-            Bytecode::OpNegate => format!("{:?}", byte),
-            Bytecode::OpGreater => format!("{:?}", byte),
-            Bytecode::OpLess => format!("{:?}", byte),
-            Bytecode::OpGreaterEqual => format!("{:?}", byte),
-            Bytecode::OpLessEqual => format!("{:?}", byte),
-            Bytecode::OpPrint => format!("{:?}", byte),
-            Bytecode::OpConstant => {
+            OpPop | OpMul | OpAdd | OpDiv | OpSub | OpNot | OpEqual | OpNegate | OpGreater
+            | OpLess | OpGreaterEqual | OpLessEqual | OpPrint | OpStructAccess | OpCall => {
+                format!("{:?}", byte)
+            }
+            OpConstant => {
                 let index = read_u16(bytes);
                 format!("{:?} {}", byte, constants[index as usize])
             }
-            Bytecode::OpDefineGlobal => {
+            OpDefineGlobal => {
                 let index = read_u16(bytes);
                 format!("{:?} {}", byte, constants[index as usize])
             }
-            Bytecode::OpSetGlobal => {
+            OpSetGlobal => {
                 let index = read_u16(bytes);
                 format!("{:?} {}", byte, constants[index as usize])
             }
-            Bytecode::OpGetGlobal => {
+            OpGetGlobal => {
                 let index = read_u16(bytes);
                 format!("{:?} {}", byte, constants[index as usize])
             }
-            Bytecode::OpSetLocal => {
+            OpSetLocal => {
                 let index = read_u8(bytes);
                 format!("{:?} {}", byte, index)
             }
-            Bytecode::OpGetLocal => {
+            OpGetLocal => {
                 let index = read_u8(bytes);
                 format!("{:?} {}", byte, index)
             }
-            Bytecode::OpJumpIfFalse => {
+            OpJumpIfFalse => {
                 let index = read_u16(bytes);
                 format!("{:?} -> {}", byte, index)
             }
-            Bytecode::OpJump => {
+            OpJump => {
                 let index = read_u16(bytes);
                 format!("{:?} -> {}", byte, index)
             }
-            Bytecode::OpLoop => {
+            OpLoop => {
                 let index = read_u16(bytes);
                 format!("{:?} -> {}", byte, index)
             }
-            Bytecode::OpStructInit => {
+            OpStructInit => {
                 let index = read_u8(bytes);
                 format!("{:?} of len {}", byte, index)
             }
-            Bytecode::OpStructAccess => format!("{:?}", byte),
-            Bytecode::OpReturn => {
+            OpReturn => {
                 let retvals = read_u8(bytes);
                 let pop = read_u8(bytes);
                 format!("{:?} {} vals, pop {}", byte, retvals, pop)
             }
-            Bytecode::OpCall => format!("{:?}", byte),
         };
         Some((index, res))
     } else {

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,10 +26,7 @@ impl Value {
 pub enum Object {
     StringObj(String),
     FnObj(String, Chunk, u8),
-    StructObj {
-        name: String,
-        fields: HashMap<String, Value>,
-    },
+    StructObj { fields: HashMap<String, Value> },
 }
 
 #[derive(Debug)]
@@ -57,6 +54,7 @@ pub enum Bytecode {
     OpJumpIfFalse,
     OpLoop,
     OpCall,
+    OpStructInit,
     OpPrint,
     OpReturn,
 }
@@ -294,7 +292,7 @@ impl fmt::Display for Object {
         match self {
             Object::StringObj(str_) => write!(f, "{}", str_),
             Object::FnObj(name, _chunk, arity) => write!(f, "{} (args: {})", name, arity),
-            Object::StructObj { name, .. } => write!(f, "struct {}", name),
+            Object::StructObj { .. } => write!(f, "struct"),
         }
     }
 }
@@ -372,6 +370,10 @@ fn byte_to_opcode(
             Bytecode::OpLoop => {
                 let index = read_u16(bytes);
                 format!("{:?} -> {}", byte, index)
+            }
+            Bytecode::OpStructInit => {
+                let index = read_u8(bytes);
+                format!("{:?} of len {}", byte, index)
             }
             Bytecode::OpReturn => {
                 let retvals = read_u8(bytes);

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,11 +13,35 @@ pub enum Value {
 }
 
 impl Value {
-    pub fn unwrap_bool(&self) -> bool {
+    pub fn unwrap_bool(self) -> bool {
         if let Value::Bool(b) = self {
-            *b
+            b
         } else {
             panic!("Expected bool.");
+        }
+    }
+
+    pub fn unwrap_obj(self) -> Object {
+        if let Value::Obj(obj) = self {
+            obj
+        } else {
+            panic!("Expected Object.");
+        }
+    }
+
+    pub fn unwrap_int(self) -> i32 {
+        if let Value::Int(int) = self {
+            int
+        } else {
+            panic!("Expected i32.");
+        }
+    }
+
+    pub fn unwrap_double(self) -> f32 {
+        if let Value::Double(double) = self {
+            double
+        } else {
+            panic!("Expected f32.");
         }
     }
 }
@@ -27,6 +51,24 @@ pub enum Object {
     StringObj(String),
     FnObj(String, Chunk, u8),
     StructObj { fields: HashMap<String, Value> },
+}
+
+impl Object {
+    pub fn unwrap_string(self) -> String {
+        if let Object::StringObj(str_) = self {
+            str_
+        } else {
+            panic!("Expected String.");
+        }
+    }
+
+    pub fn unwrap_struct(self) -> HashMap<String, Value> {
+        if let Object::StructObj { fields } = self {
+            fields
+        } else {
+            panic!("Expected struct obj.");
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -98,6 +98,7 @@ pub enum Bytecode {
     OpCall,
     OpStructInit,
     OpStructAccess,
+    OpStructWrite,
     OpPrint,
     OpReturn,
 }
@@ -368,9 +369,8 @@ fn byte_to_opcode(
         let byte = unsafe { std::mem::transmute::<u8, Bytecode>(*byte_) };
         let res = match byte {
             OpPop | OpMul | OpAdd | OpDiv | OpSub | OpNot | OpEqual | OpNegate | OpGreater
-            | OpLess | OpGreaterEqual | OpLessEqual | OpPrint | OpStructAccess | OpCall => {
-                format!("{:?}", byte)
-            }
+            | OpLess | OpGreaterEqual | OpLessEqual | OpPrint | OpStructAccess | OpCall
+            | OpStructWrite => format!("{:?}", byte),
             OpConstant => {
                 let index = read_u16(bytes);
                 format!("{:?} {}", byte, constants[index as usize])

--- a/src/types.rs
+++ b/src/types.rs
@@ -281,7 +281,7 @@ impl fmt::Display for Object {
         match self {
             Object::StringObj(str_) => write!(f, "{}", str_),
             Object::FnObj(name, _chunk, arity) => write!(f, "{} (args: {})", name, arity),
-            Object::StructObj { name, fields } => write!(f, "struct {}", name),
+            Object::StructObj { name, .. } => write!(f, "struct {}", name),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,6 +55,7 @@ pub enum Bytecode {
     OpLoop,
     OpCall,
     OpStructInit,
+    OpStructAccess,
     OpPrint,
     OpReturn,
 }
@@ -375,6 +376,7 @@ fn byte_to_opcode(
                 let index = read_u8(bytes);
                 format!("{:?} of len {}", byte, index)
             }
+            Bytecode::OpStructAccess => format!("{:?}", byte),
             Bytecode::OpReturn => {
                 let retvals = read_u8(bytes);
                 let pop = read_u8(bytes);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,6 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::ops::Range;
-use std::collections::HashMap;
 
 pub type Program = Vec<Declaration>;
 
@@ -26,7 +26,10 @@ impl Value {
 pub enum Object {
     StringObj(String),
     FnObj(String, Chunk, u8),
-    StructObj { name: String, fields: HashMap<String, Value> },
+    StructObj {
+        name: String,
+        fields: HashMap<String, Value>,
+    },
 }
 
 #[derive(Debug)]
@@ -137,6 +140,14 @@ impl Into<std::ops::Range<usize>> for Token {
     }
 }
 
+#[derive(Debug)]
+pub struct CompileError {
+    /// The indexes in the source string that are erroneous
+    pub token_range: Range<usize>,
+    /// The error message
+    pub message: String,
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum TokenKind {
     Semicolon,
@@ -207,10 +218,19 @@ pub enum ExpressionKind {
     Assign(String, Box<Expression>),
     Unary(Token, Box<Expression>),
     Call(Box<Expression>, Vec<Expression>),
-    StructInit { name: Token, values: Vec<(Expression, Expression)> },
-    Integer { int: i32 },
-    Double { float: f32 },
-    Str { string: String },
+    StructInit {
+        name: Box<Expression>,
+        values: Vec<(Expression, Expression)>,
+    },
+    Integer {
+        int: i32,
+    },
+    Double {
+        float: f32,
+    },
+    Str {
+        string: String,
+    },
     Identifier(String),
     False,
     True,
@@ -228,6 +248,14 @@ impl Expression {
 
     pub fn new_debug(kind: ExpressionKind) -> Self {
         Expression { tokens: 0..1, kind }
+    }
+
+    pub fn get_id(&self) -> String {
+        if let ExpressionKind::Identifier(id) = &self.kind {
+            id.clone()
+        } else {
+            panic!("Expected IdToken");
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -116,6 +116,12 @@ impl Token {
         }
     }
 
+    pub fn from_range(range: &Range<usize>, kind: TokenKind) -> Self {
+        let start = range.start as u32;
+        let offset = (range.end - range.start) as u8;
+        Self::new(start, offset, kind)
+    }
+
     pub fn is_id_token(&self) -> bool {
         if let TokenKind::IdToken(_) = self.kind {
             true

--- a/src/util.rs
+++ b/src/util.rs
@@ -116,11 +116,11 @@ pub fn pretty_write_expr(
             }
             pretty_write_expr(f, level, true, callee)
         }
-        Assign(id, expr) => {
+        Assign { target, value } => {
             write(f, level, is_child, "Assign")?;
             level += 2;
-            write(f, level, is_child, id)?;
-            pretty_write_expr(f, level, true, expr)
+            pretty_write_expr(f, level, true, target)?;
+            pretty_write_expr(f, level, true, value)
         }
         StructInit { name, values } => {
             write(f, level, is_child, &format!("Struct {}", name.get_id()))?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -133,6 +133,12 @@ pub fn pretty_write_expr(
             }
             Ok(())
         }
+        Access { expr, name } => {
+            write(f, level, is_child, "Access")?;
+            level += 2;
+            pretty_write_expr(f, level, is_child, expr)?;
+            pretty_write_expr(f, level, is_child, name)
+        }
         Integer { int } => write(f, level, is_child, &format!("{}", int)),
         Double { float } => write(f, level, is_child, &format!("{}", float)),
         Str { string } => write(f, level, is_child, &format!("\"{}\"", string)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -122,12 +122,17 @@ pub fn pretty_write_expr(
             write(f, level, is_child, id)?;
             pretty_write_expr(f, level, true, expr)
         }
-        StructInit { name, .. } => write(
-            f,
-            level,
-            is_child,
-            &format!("Struct {} (todo)", name.get_id()),
-        ),
+        StructInit { name, values } => {
+            write(f, level, is_child, &format!("Struct {}", name.get_id()))?;
+            level += 2;
+            for (name, value) in values.iter() {
+                let mut temp = level;
+                pretty_write_expr(f, temp, true, name)?;
+                temp += 2;
+                pretty_write_expr(f, temp, true, value)?;
+            }
+            Ok(())
+        }
         Integer { int } => write(f, level, is_child, &format!("{}", int)),
         Double { float } => write(f, level, is_child, &format!("{}", float)),
         Str { string } => write(f, level, is_child, &format!("\"{}\"", string)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -122,6 +122,12 @@ pub fn pretty_write_expr(
             write(f, level, is_child, id)?;
             pretty_write_expr(f, level, true, expr)
         }
+        StructInit { name, .. } => write(
+            f,
+            level,
+            is_child,
+            &format!("Struct {} (todo)", name.get_id()),
+        ),
         Integer { int } => write(f, level, is_child, &format!("{}", int)),
         Double { float } => write(f, level, is_child, &format!("{}", float)),
         Str { string } => write(f, level, is_child, &format!("\"{}\"", string)),
@@ -320,7 +326,7 @@ pub fn run(program: String, options: &Options) {
             }
         }
         Err(parser_err) => {
-            print_error(&program, parser_err.token.into(), parser_err.message);
+            print_error(&program, parser_err.token_range, &parser_err.message);
         }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -97,7 +97,6 @@ impl VM {
                         let field_value = self.pop();
 
                         if let Value::Obj(Object::StringObj(field_name)) = field_name {
-                            println!("Adding {} with value {}", field_name, field_value);
                             field_value_map.insert(field_name, field_value);
                         } else {
                             panic!("Expected string as field name.");
@@ -106,6 +105,19 @@ impl VM {
                     self.push(Value::Obj(Object::StructObj {
                         fields: field_value_map,
                     }));
+                }
+                OpStructAccess => {
+                    let field_name = self.pop();
+                    let struct_ = self.pop();
+                    if let Value::Obj(Object::StringObj(field_name)) = field_name {
+                        if let Value::Obj(Object::StructObj { fields }) = struct_ {
+                            self.push(fields.get(&field_name).unwrap().clone());
+                        } else {
+                            panic!("Expected struct");
+                        }
+                    } else {
+                        panic!("Expected string as field name");
+                    }
                 }
                 OpCall => {
                     if let Value::Obj(Object::FnObj(_name, chunk, arity)) = self.pop() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -93,31 +93,19 @@ impl VM {
                     let struct_length = self.read_u8(chunk, &mut i);
                     let mut field_value_map = HashMap::new();
                     for _ in 0..struct_length {
-                        let field_name = self.pop();
+                        let field_name = self.pop().unwrap_obj().unwrap_string();
                         let field_value = self.pop();
-
-                        if let Value::Obj(Object::StringObj(field_name)) = field_name {
-                            field_value_map.insert(field_name, field_value);
-                        } else {
-                            panic!("Expected string as field name.");
-                        }
+                        field_value_map.insert(field_name, field_value);
                     }
+
                     self.push(Value::Obj(Object::StructObj {
                         fields: field_value_map,
                     }));
                 }
                 OpStructAccess => {
-                    let field_name = self.pop();
-                    let struct_ = self.pop();
-                    if let Value::Obj(Object::StringObj(field_name)) = field_name {
-                        if let Value::Obj(Object::StructObj { fields }) = struct_ {
-                            self.push(fields.get(&field_name).unwrap().clone());
-                        } else {
-                            panic!("Expected struct");
-                        }
-                    } else {
-                        panic!("Expected string as field name");
-                    }
+                    let field_name = self.pop().unwrap_obj().unwrap_string();
+                    let fields = self.pop().unwrap_obj().unwrap_struct();
+                    self.push(fields.get(&field_name).unwrap().clone());
                 }
                 OpCall => {
                     if let Value::Obj(Object::FnObj(_name, chunk, arity)) = self.pop() {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -109,15 +109,38 @@ impl VM {
                 }
                 OpStructWrite => {
                     let struct_stack_index = self.read_u8(chunk, &mut i) as usize;
-                    let field_name = self.pop().unwrap_obj().unwrap_string();
+                    let write_depth = self.read_u8(chunk, &mut i) as usize;
+
+                    let mut field_names = Vec::with_capacity(write_depth as usize);
+
+                    for _ in 0..write_depth {
+                        field_names.push(self.pop().unwrap_obj().unwrap_string());
+                    }
+
                     let new_field_value = self.pop();
 
-                    let mut struct_ = &mut self.stack[self.frame_pointer + struct_stack_index];
+                    let struct_ = &mut self.stack[self.frame_pointer + struct_stack_index];
+                    let mut value_ptr = struct_ as *mut Value;
 
-                    if let Value::Obj(Object::StructObj { fields }) = &mut struct_ {
-                        fields.insert(field_name, new_field_value);
-                    } else {
-                        panic!("Expected struct");
+                    for field_name in field_names {
+                        // Type Checker guarantees that every new field we lookup is a struct
+                        if let Value::Obj(Object::StructObj { fields }) = unsafe { &mut *value_ptr }
+                        {
+                            match fields.get_mut(&field_name) {
+                                Some(value @ Value::Obj(_)) => {
+                                    value_ptr = value as *mut Value;
+                                }
+                                _ => panic!("Expected struct or field"),
+                            }
+                        } else {
+                            panic!("Expected struct");
+                        }
+                    }
+
+                    // After the loop exits, value_ptr points at the innermost field
+                    // that we want to write the new value to
+                    unsafe {
+                        *value_ptr = new_field_value;
                     }
                 }
                 OpCall => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -89,6 +89,24 @@ impl VM {
                     let index = self.read_u16(chunk, &mut i);
                     i = index as usize - 1;
                 }
+                OpStructInit => {
+                    let struct_length = self.read_u8(chunk, &mut i);
+                    let mut field_value_map = HashMap::new();
+                    for _ in 0..struct_length {
+                        let field_name = self.pop();
+                        let field_value = self.pop();
+
+                        if let Value::Obj(Object::StringObj(field_name)) = field_name {
+                            println!("Adding {} with value {}", field_name, field_value);
+                            field_value_map.insert(field_name, field_value);
+                        } else {
+                            panic!("Expected string as field name.");
+                        }
+                    }
+                    self.push(Value::Obj(Object::StructObj {
+                        fields: field_value_map,
+                    }));
+                }
                 OpCall => {
                     if let Value::Obj(Object::FnObj(_name, chunk, arity)) = self.pop() {
                         // Save the position of the current frame pointer

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -107,6 +107,19 @@ impl VM {
                     let fields = self.pop().unwrap_obj().unwrap_struct();
                     self.push(fields.get(&field_name).unwrap().clone());
                 }
+                OpStructWrite => {
+                    let struct_stack_index = self.read_u8(chunk, &mut i) as usize;
+                    let field_name = self.pop().unwrap_obj().unwrap_string();
+                    let new_field_value = self.pop();
+
+                    let mut struct_ = &mut self.stack[self.frame_pointer + struct_stack_index];
+
+                    if let Value::Obj(Object::StructObj { fields }) = &mut struct_ {
+                        fields.insert(field_name, new_field_value);
+                    } else {
+                        panic!("Expected struct");
+                    }
+                }
                 OpCall => {
                     if let Value::Obj(Object::FnObj(_name, chunk, arity)) = self.pop() {
                         // Save the position of the current frame pointer


### PR DESCRIPTION
Parse, type check, compile and execute structs.

Specifically, it allows declaring structs

```
struct Dog {
    name: str,
    age: i32,
}
```

accessing its fields
```
print dog.name;
```

and writing to its fields
```
dog.name = "Doggo";
```